### PR TITLE
Allow groups’ admins to accept/reject new members to groups

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,8 @@ var groupsRouter = require('./routes/groups');
 var createGroupRouter = require('./routes/createGroups');
 var editGroupRouter = require('./routes/editGroup');
 var addtoGroupRouter = require('./routes/addToGroup');
+var groupRequestRouter = require('./routes/groupRequest');
+var declineGroupRequestRouter = require('./routes/declineGroupRequest');
 
 var wallRouter = require('./routes/goToWall');
 
@@ -96,7 +98,8 @@ app.use('/groups',groupsRouter);
 app.use('/createGroups',createGroupRouter);
 app.use('/editGroup',editGroupRouter);
 app.use('/addToGroup',addtoGroupRouter);
-
+app.use('/groupRequest', groupRequestRouter);
+app.use('/declineGroupRequest', declineGroupRequestRouter);
 
 
 

--- a/routes/addToGroup.js
+++ b/routes/addToGroup.js
@@ -39,21 +39,29 @@ pool.connection.query(groupADD, function (err, result){
 //Getting the members list
 var selectMembers = "SELECT Fname,Lname,groupName,memberID FROM groups where groupID='"+gID+"';";
 
-            pool.connection.query(selectMembers, function (error, results) {
-              if (error)
-                 throw error;
+//Handling requests 
+var groupStatus = "SELECT Fname,Lname,groupName,memberID,groupID FROM groups where memberID='"+loggedInID+"' AND groupID='"+gID+"';";
+var selectRequests = "SELECT requesterID,Fname,Lname,groupID,leaderID FROM grouprequests where groupID='"+gID+"';";
+var removeRequest = "DELETE FROM grouprequests where requesterID='"+memberID+"';";
+
+  pool.connection.query(removeRequest, function (error, del) {
+      pool.connection.query(selectRequests, function (error, requests) {
+          pool.connection.query(groupStatus, function (error, results1) {
+              if (error) throw error;
+              pool.connection.query(selectMembers, function (error, results) {
+                if (error) throw error;
 
               let getUser = new Promise(function(resolve, reject){
                 resolve(functions.getUser(loggedInID));
               });
               getUser.then(function(user){
-                res.render('editGroup', {groupMembers: results,uID : loggedInID, groupID : gID, groupName : results[0].groupName, name:user.Fname});
-              });
-              });
-
-
+                res.render('editGroup', {groupMembers : results, groupID : gID, uID : loggedInID, groupName : results[0].groupName, name: user.Fname , leader: results[0], memberStatus: results1[0], groupRequests : requests});
+                  });
+                });
+            });
+          });
       });
-
+    });
 });
 });
 

--- a/routes/declineGroupRequest.js
+++ b/routes/declineGroupRequest.js
@@ -1,0 +1,59 @@
+var express = require('express');
+var router = express.Router();
+var app = express();
+var bodyParser = require("body-parser");
+var mysql = require('mysql');
+var DBconnect = require('./dbConfig');
+var functions = require('./functions');
+
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
+
+var pool = new DBconnect();
+
+
+router.post('/', function (req,res) {
+  //GET ids.
+    var loggedInID = req.body.logID;
+    var memberID = req.body.idToAdd;
+    var gID = req.body.groupID;
+    var gName = req.body.groupName;
+
+
+    var sql = "SELECT Fname,Lname FROM users where ID='"+memberID+"';";
+
+pool.connection.query(sql, function (err, result){
+      if (err) throw err;
+
+      memberFname = result[0].Fname;
+      memberLname = result[0].Lname;
+
+//Getting the members list
+var selectMembers = "SELECT Fname,Lname,groupName,memberID FROM groups where groupID='"+gID+"';";
+
+//Handling requests 
+var groupStatus = "SELECT Fname,Lname,groupName,memberID,groupID FROM groups where memberID='"+loggedInID+"' AND groupID='"+gID+"';";
+var selectRequests = "SELECT requesterID,Fname,Lname,groupID,leaderID FROM grouprequests where groupID='"+gID+"';";
+var removeRequest = "DELETE FROM grouprequests where requesterID='"+memberID+"';";
+
+  pool.connection.query(removeRequest, function (error, del) {
+      pool.connection.query(selectRequests, function (error, requests) {
+          pool.connection.query(groupStatus, function (error, results1) {
+              if (error) throw error;
+              pool.connection.query(selectMembers, function (error, results) {
+                if (error) throw error;
+
+              let getUser = new Promise(function(resolve, reject){
+                resolve(functions.getUser(loggedInID));
+              });
+              getUser.then(function(user){
+                res.render('editGroup', {groupMembers : results, groupID : gID, uID : loggedInID, groupName : results[0].groupName, name: user.Fname , leader: results[0], memberStatus: results1[0], groupRequests : requests});
+                  });
+                });
+            });
+          });
+    });
+});
+});
+
+module.exports=router;

--- a/routes/editGroup.js
+++ b/routes/editGroup.js
@@ -20,30 +20,38 @@ router.post('/', function(req, res, next) {
     var userID = req.body.userID;
     var gID = req.body.groupID;
 
+  //Checking if the user is part of the group. 
+  var groupStatus = "SELECT Fname,Lname,groupName,memberID,groupID FROM groups where memberID='"+userID+"' AND groupID='"+gID+"';";
 
+
+    // Get group members
     var selectGroup = "SELECT Fname,Lname,groupName,memberID,groupID FROM groups where groupID='"+gID+"';";
 
+    //Get pending requests 
+    var selectRequests = "SELECT requesterID,Fname,Lname,groupID,leaderID FROM grouprequests where groupID='"+gID+"';";
 
+
+pool.connection.query(selectRequests, function (error, requests) {
+    if (error)throw error;
+pool.connection.query(groupStatus, function (error, result) {
+    if (error)throw error;
     pool.connection.query(selectGroup, function (error, results) {
         if (error)
             throw error;
+
+
+            console.log(result[0])
+
 
         let getUser = new Promise(function(resolve, reject){
           resolve(functions.getUser(userID));
         });
         getUser.then(function(user){
-          res.render('editGroup', {groupMembers : results, groupID : gID, uID : userID, groupName : results[0].groupName, name: user.Fname});
+          res.render('editGroup', {groupMembers : results, groupID : gID, uID : userID, groupName : results[0].groupName, name: user.Fname , leader: results[0], memberStatus: result[0], groupRequests : requests});
         });
     });
-
-
-
-
-
-
-
-
 });
-
+});
+});
 
 module.exports = router;

--- a/routes/friends.js
+++ b/routes/friends.js
@@ -15,6 +15,14 @@ var pool = new DBconnect();
 
 router.post('/', function(req, res, next) {
 
+    var userID = req.body.userID;
+    var userName = req.body.userName;
+
+    var friendsList = "SELECT friendName,f2 FROM friends where f1='"+userID+"';";
+
+    pool.connection.query(friendsList, function (error, results) {
+        if (error)
+            throw error;
 
 
           res.render('friends', {friendsList: results, userID : userID, name:userName});
@@ -28,6 +36,7 @@ router.post('/', function(req, res, next) {
 
 
 
+});
 
 
 module.exports = router;

--- a/routes/groupRequest.js
+++ b/routes/groupRequest.js
@@ -1,0 +1,63 @@
+var express = require('express');
+var router = express.Router();
+var app = express();
+var bodyParser = require("body-parser");
+var mysql = require('mysql');
+var DBconnect = require('./dbConfig');
+var functions = require('./functions');
+
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
+
+var pool = new DBconnect();
+
+
+router.post('/', function(req, res, next) {
+
+
+  var userID = req.body.logID;
+  var gID = req.body.groupID;
+  var leaderID = req.body.leaderID;
+
+var userToAdd = "SELECT Fname,Lname,ID FROM users where ID='"+userID+"';";
+var groupStatus = "SELECT Fname,Lname,groupName,memberID,groupID FROM groups where memberID='"+userID+"' AND groupID='"+gID+"';";
+var selectGroup = "SELECT Fname,Lname,groupName,memberID,groupID FROM groups where groupID='"+gID+"';";
+var selectRequests = "SELECT requesterID,Fname,Lname,groupID,leaderID FROM grouprequests where groupID='"+gID+"';";
+
+ pool.connection.query(groupStatus, function (error, results1) {
+  if (error)throw error;
+  pool.connection.query(selectGroup, function (error, results2) {
+      if (error)
+          throw error;
+    pool.connection.query(userToAdd, function (error, result) {
+         if (error)throw error;
+        
+
+  var userFname = result[0].Fname;
+  var userLname = result[0].Lname;
+ 
+
+
+ // Get group members
+ var addRequest = "INSERT INTO  grouprequests (requesterID,Fname,Lname, groupID, leaderID) VALUES ('"+userID+"','"+userFname+"','"+userLname+"','"+gID+"','"+leaderID+"')";
+
+        pool.connection.query(addRequest, function (error, results) {
+            if (error)
+               throw error;
+                pool.connection.query(selectRequests, function (error, requests) {
+                  if (error)throw error;
+
+          let getUser = new Promise(function(resolve, reject){
+            resolve(functions.getUser(userID));
+          });
+          getUser.then(function(user){
+          res.render('editGroup', {groupMembers : results2, groupID : gID, uID : userID, groupName : results2[0].groupName, name: user.Fname , leader: results2[0], memberStatus: results1[0], groupRequests : requests});
+          });
+        });
+      });
+    });
+  });
+ });
+});
+
+module.exports=router;

--- a/routes/searchUsers.js
+++ b/routes/searchUsers.js
@@ -26,12 +26,14 @@ router.post('/', function (req,res) {
 
    var selectGroup = "SELECT Fname,Lname,groupName,memberID FROM groups where groupID='"+gID+"';";
 
-pool.connection.query(selectGroup, function (error, result1) {
-pool.connection.query(memberList, function (error, result){
-    pool.connection.query(query, function (error, results) {
-      if (error)
-          throw error;
+      pool.connection.query(selectGroup, function (error, result1) {
+        if (error)throw error;
+          pool.connection.query(memberList, function (error, result){
+            if (error)throw error;
+              pool.connection.query(query, function (error, results) {
+                 if (error)throw error;
 
+                      
           var users=[];
           var ids=[];
 
@@ -60,15 +62,24 @@ pool.connection.query(memberList, function (error, result){
 
           }
 
-          let getUser = new Promise(function(resolve, reject){
-            resolve(functions.getUser(loggedInID));
-          });
-          getUser.then(function(user){
-            res.render('editGroup', {groupMembers : result1, queryResults: users, idKeys: ids, uID : loggedInID, userList: result, groupName: nameG, groupID : gID, name:user.Fname});
-          });
-    });
+//Handling requests 
+var groupStatus = "SELECT Fname,Lname,groupName,memberID,groupID FROM groups where memberID='"+loggedInID+"' AND groupID='"+gID+"';";
+var selectRequests = "SELECT requesterID,Fname,Lname,groupID,leaderID FROM grouprequests where groupID='"+gID+"';";
 
-});
-});
+                pool.connection.query(selectRequests, function (error, requests) {
+                    pool.connection.query(groupStatus, function (error, result2) {
+                         let getUser = new Promise(function(resolve, reject){
+                            resolve(functions.getUser(loggedInID));
+                              });
+
+        getUser.then(function(user){
+
+           res.render('editGroup', {groupMembers : result1, queryResults: users, idKeys: ids, uID : loggedInID, userList: result, groupName: nameG, groupID : gID, name:user.Fname, leader: result1[0], memberStatus: result2[0], groupRequests : requests});
+        });
+              });
+            });
+          });
+        });
+      });
 });
 module.exports=router;

--- a/routes/viewFriendProfile.js
+++ b/routes/viewFriendProfile.js
@@ -17,11 +17,16 @@ router.post('/', function(req, res, next) {
     var userID = req.body.userID;
     var friendID = req.body.friendID;
 
-
-
+    var groups = "SELECT groupID, groupName from groups where memberID='"+friendID+"';";
+    var friends = "SELECT friendName,f2 FROM friends where f1='"+friendID+"';";
     var theSQL = "SELECT ID, Email, Pass, Fname, Lname, isTeacher from Users where ID='"+friendID+"';";
     //looking into the teachers table and return the results. If the result is there, then its length would be > 0.
+
     pool.connection.query(theSQL, function (err, result){
+        if (err) throw err;
+      pool.connection.query(groups, function (err, result2){
+        if (err) throw err;
+        pool.connection.query(friends, function (err, result3){
         if (err) throw err;
         var userType;
         //if searching in the parent table is succesful.
@@ -42,7 +47,7 @@ router.post('/', function(req, res, next) {
               resolve(functions.getUser(userID));
             });
             getUser.then(function(user){
-              res.render('friendProfile', {userType:userType, userID:user.ID, friendID:teacherID, friendName:teacherFname,name:user.Fname, userLname:teacherLname, userEmail:teacherEmail, userPass:teacherPass});
+              res.render('friendProfile', {userType:userType, userID:user.ID, friendID:teacherID, friendName:teacherFname,name:user.Fname, userLname:teacherLname, userEmail:teacherEmail, userPass:teacherPass, groupList: result2, friendsList: result3});
             });
         }
         else{
@@ -50,8 +55,8 @@ router.post('/', function(req, res, next) {
 
         };
     });
-
-
+  });
+});
 
 
 

--- a/stylesheets/styles_groups.css
+++ b/stylesheets/styles_groups.css
@@ -108,9 +108,11 @@ body{
 
   
     margin-top: -100vh;
-    margin-left:400px;
-    width:100%;
+    margin-left:190px;
+    width: 100%;
      text-align: center;
+    
+     height: 100vh;
 }
     
 .list_Header{
@@ -122,13 +124,14 @@ body{
 #fListTitle{
     
     font-size: 25px;
+    font-weight: bold;
+   
         
 }
         
 .editGroupPage_content{
 
     width: 100vh;
-	border-right-color: black;
     margin-left: 285px;
     margin-top: 70px;
     height: 100%;
@@ -140,7 +143,7 @@ body{
 
 .search{
 border-right: solid;
-width: 60%;
+width: 40%;
 height: 100vh;
 
 
@@ -158,7 +161,7 @@ height: 100vh;
 #searchTitle{
 
     font-size: 25px;
-
+    font-weight: bold;
     
 }
 
@@ -169,7 +172,7 @@ height: 100vh;
 
 .groupNAME{
    
-    margin: 50vh;
+    margin: 50%;
     text-align: center;
     font-weight: bold;
     font-size: 40px;
@@ -222,4 +225,101 @@ height: 100vh;
 tr td{
     border-top: 1px solid rgba(192, 192, 192, 0.993);
     padding: 5px;
+}
+
+
+.requestBtn{
+
+    cursor: pointer;
+    border: none;
+    padding: 3px;
+    background-color: rgb(207, 207, 207);
+    border-radius: 2px;
+    font-weight: bold;
+
+}
+
+
+.requestBtn:hover{
+    background-color: rgb(182, 182, 182);
+    cursor: pointer;
+    
+}
+
+#memberStatus{
+
+  color: rgb(163, 18, 18);
+  font-weight: bold;
+
+}
+
+.requests_List{
+
+    margin-top: -100vh;
+    margin-left:900px;
+    width: 70%;
+    height: 100vh;
+     text-align: center;
+     border-left:solid;
+
+}
+#rListTitle{
+
+    font-size: 25px;
+    margin-right: 200px;
+    font-weight: bold;
+}
+
+.requestListTable{
+
+    margin-top: 10px;
+    margin-left: 40px;
+    width: 60%;
+	font-size: 20px;
+	border-bottom: 1px solid rgba(192, 192, 192, 0.993);
+    text-align: center;
+   
+}
+
+
+.acceptBtn{
+    
+    font-size: 15px;
+    width: wrap;
+    cursor: pointer;
+    font-weight: bold;
+    background-color: rgb(114, 226, 2);
+    padding: 5px;
+  
+    
+
+}
+
+.acceptBtn:hover{
+    cursor: pointer;
+    background-color: rgb(127, 255, 0);
+
+}
+
+.declineBtn{
+
+    font-size: 15px;
+    width: wrap;
+    cursor: pointer;
+    font-weight: bold;
+    background-color: rgb(202, 0, 0);
+    padding: 5px;
+}
+
+
+.declineBtn:hover{
+    cursor: pointer;
+    background-color: rgb(255, 0, 0);
+    
+
+}
+
+#noRequests{
+
+    color: rgb(163, 18, 18);
 }

--- a/views/editGroup.ejs
+++ b/views/editGroup.ejs
@@ -98,9 +98,32 @@
 
         <% if(typeof groupName !== 'undefined'){ %>
        <p class="groupNAME"><%=groupName%></p>
+            
             <% } %>
         <hr>
 
+
+        <form action="/groupRequest" method="POST" onsubmit="return alert('Request Sent to Group Admin')">
+            <!-- Not a member -->
+            <% if(typeof memberStatus == 'undefined'){ %>
+                <input type="text" name ="leaderID" style="display:none" value = "<%= leader.memberID%>">
+                <input type="text" name ="groupID" style="display:none" value = "<%= groupID%>">
+                <input type="text" name ="logID" style="display:none" value = "<%= uID%>">
+        <span id="memberStatus">You are not a member of this group. Would you like to send a request to the group leader to join?</span>     
+            <button name="groupRequest" type="submit" class="requestBtn">Send Request</button>
+            <% } %>
+            <!-- Member -->
+            <% if(typeof memberStatus !== 'undefined' && leader.memberID != uID ){ %>
+                <span id="memberStatus">You are a member of this group.</span>
+                <% } %>
+            <!-- Leader  -->
+            <% if(leader.memberID == uID){ %>
+                <span id="memberStatus">You are the leader of this group.</span>
+                <% } %>
+            </form>
+
+
+            <hr>
             <div class="search">
 
                 <div class="searchBar">
@@ -112,7 +135,7 @@
                         <input type="text" name ="groupName" style="display:none" value = "<%= groupName%>">
                         <input type="text" name ="groupID" style="display:none" value = "<%= groupID%>">
                         <% } %>
-                    <input type="text" name ="logID" style="display:none" value = "<%= uID%>"></td>
+                    <input type="text" name ="logID" style="display:none" value = "<%= uID%>">
                     <input type="text" name="searchField" class="searchField1" placeholder="Search">
                     <button name="searchUsersBtn" class="searchUsersBtn">Search</button>
                         </form>
@@ -138,6 +161,8 @@
                                  <% }else{ %>
 
                                  <td class="person" style="padding-left:20px;"><span><%= u %></span></td>
+
+                                 <% if(leader.memberID == uID || typeof memberStatus !== 'undefined' ){ %>
                                           <form action="/addToGroup" method="POST">
 
 
@@ -148,9 +173,12 @@
                                         <% } %>
                                         <td class="person" style="text-align:center;"><input type="text"name="logID" style="display:none" value = "<%=uID%>"></td>
                                         <td class="person" style="text-align:center;"><input type="text"name ="idToAdd" style="display:none;" value = "<%=key %>"></td>
-                                              <td> <button name="groupInviteBtn" class="groupInviteBtn" >Send Invite</button> </td>
+                                        
+                                              <td> <button name="groupInviteBtn" class="groupInviteBtn" >Add to Group</button> </td>
+                                              
                                          </form>
-
+                                         <% } %>
+                                        
                                      <% } %>
                                        </tr>
                             <% n++; %>
@@ -191,13 +219,73 @@
                                             <% }) %>
                                     <% } %>
                             </table>
+                            
                     </div>
 
                 </div>
 
+                <div class="requests_List">
+      
+                        <% if(leader.memberID == uID){ %>  
+                        <p id="rListTitle"> Pending Requests</p>
+                       
+                            <div class="list_Header">
+                                    
+                                    <table class="requestListTable">
+                
+                                        
+                                            <% if(typeof groupRequests !== 'undefined'){ %>
+                                            
+                                                    <% groupRequests.forEach(function(v){ %>
+              
+                                                      
+                                            <tr class="memberTableRow">
+            
+                                         <td class="member" style="text-align: center; padding: 10px;";><span class="memberName"> <%= v.Fname%> <%= v.Lname%></span></td>
+                
 
+                                         <form action="/addToGroup" method="POST">
+                                            <input type="text" name ="logID" style="display:none" value = "<%= uID%>">
+                                            <input type="text" name ="groupID" style="display:none" value = "<%= groupID%>">
+                                            <input type="text" name ="groupName" style="display:none" value = "<%= groupName%>">
+                                            <input type="text"name ="idToAdd" style="display:none;" value = "<%=v.requesterID %>">
+                                         <td class="member"><button name="accept" class="acceptBtn" >Accept</button>
+                                        </form>
 
-        </div>
+                                       
+                                        <form action="/declineGroupRequest" method="POST">
+                                            <input type="text" name ="logID" style="display:none" value = "<%= uID%>">
+                                            <input type="text" name ="groupID" style="display:none" value = "<%= groupID%>">
+                                            <input type="text" name ="groupName" style="display:none" value = "<%= groupName%>">
+                                            <input type="text"name ="idToAdd" style="display:none;" value = "<%=v.requesterID %>">
+                                        
+                                            <td class="member"><button name="decline" class="declineBtn" >Decline</button></td>
+                                        </form>
+
+                                            </tr>
+                                          
+                                          
+
+                                                    <% }) %>
+                                            
+                                            <% if(groupRequests.length == 0){ %>
+                                                <tr class="memberTableRow">
+                                                     <td class="member"><span id="noRequests">No Pending Requests</span></td>
+                                                </tr>
+     
+                                                <% } %>
+                                            <% } %>
+                                    </table>
+
+                            </div>
+                            <% } %>
+
+                        </div>
+
+    </div>
+   
+    
+</div>
 
 
 

--- a/views/error.ejs
+++ b/views/error.ejs
@@ -1,0 +1,13 @@
+
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>Error</title>
+    <link rel="stylesheet" href="/stylesheets/style.css">
+</head>
+<body>
+<h1><%= message %></h1>
+<h2><%= error.status %></h2>
+<pre><%= error.stack %></pre>
+</body>
+</html>

--- a/views/friendProfile.ejs
+++ b/views/friendProfile.ejs
@@ -114,20 +114,20 @@
                 <table class="profileInfoTable">
 
 
-                        <tr>
+                        <tr class="tableInfoRow">
                                 <td><span class="info">Account Type: </span></td>
                                 <td> <span name="accountTp" class="userInfo"><%= userType%></span></td>
 
 
                         </tr>
 
-                    <tr>
+                        <tr class="tableInfoRow">
                             <td><span class="info">Email :</span></td>
                             <td><span name="userEmail" class="userInfo"> <%= userEmail%> </span></td>
                     </tr>
 
 
-                    <tr>
+                    <tr class="tableInfoRow">
 
                             <td><span class="info">User ID :</span></td>
                             <td><span name="childID" class="userInfo"><%= friendID%> </span></td>
@@ -138,8 +138,81 @@
                 </table>
 
 
+               
                </div>
 
+
+             <div class= "groupsNFriends" >
+              
+                    <hr>
+
+            
+                <div class="groupList">
+
+
+
+                        <table class="groupsListTable">
+
+                            <tr >
+                                <td class="group"> <span id="groupsT">Groups</span></td>
+
+                            </tr>
+        
+                                <% if(typeof groupList !== 'undefined'){ %>
+        
+                                        <% groupList.forEach(function(v){ %>
+        
+        
+        
+                                <tr class="groupTableRow">
+        
+        
+                                    <form action="/editGroup" method="POST">
+                                        
+                                        <input type="text" name="userID" style="display:none" value = "<%= userID%>">
+                                        <input type="text"name="groupID" style="display:none;" value = "<%=v.groupID%>">
+                                        
+                                        <td class="group"><button name="editGroup" class="viewGroupBtn" ><%= v.groupName%></button> </td>
+    
+                                    </form>
+                                </tr>
+                                        <% }) %>
+                                <% } %>
+                        </table>
+        
+                </div>
+        
+
+                  
+                <div class="friendsList">
+
+
+
+                        <table class="friendsListTable">
+
+                            <tr >
+                                <td class="friend"> <span id="groupsT">Friends</span></td>
+
+                            </tr>
+        
+                                <% if(typeof friendsList !== 'undefined'){ %>
+        
+                                        <% friendsList.forEach(function(v){ %>
+        
+                                <tr >
+    
+                                    <input type="text"name="friendID" style="display:none;" value = "<%=v.f2%>">
+                                        <td class="friend"><button class="friendName" ><%= v.friendName%></button> </td>
+    
+                             </tr>
+                                        <% }) %>
+                                <% } %>
+                        </table>
+        
+                </div>
+
+
+            </div>
 
 
 

--- a/views/friends.ejs
+++ b/views/friends.ejs
@@ -170,7 +170,7 @@
                                             <form action="/viewFriendProfile" method="POST">
                                               <input type="text" name="userID" style="display:none" value="<%=userID%>">
                                               <input type="text" name="friendID" style="display:none" value="<%=v.f2%>">
-                                            <td class="person"><span class="friendNam" name = "friendNam"><button name="theFriendName" class="theFriendName" style="background-color:inherit; color:inherit; border:none; cursor:pointer;"><%= v.friendName%></button></span></td>
+                                            <td class="person"><span class="friendNam" name = "friendNam"><button name="theFriendName" class="theFriendName" ><%= v.friendName%></button></span></td>
                                           </form>
 
                                     <form action="/goToWall" method="POST">

--- a/views/parenthomepage.ejs
+++ b/views/parenthomepage.ejs
@@ -160,7 +160,7 @@
                                <input type="text" name="userID" style="display:none" value = "<%= userID%>">
                                <input type="text" name="WallID" style="display:none" value = "<%= WallID%>">
                                <input type="text" name="name" style="display:none" value = "<%= name%>">
-                               <button name="toProfile" class="toProfile"><i class="material-icons" style="float: left;padding-right:10px;">account_circle</i>like</button>
+                               <button name="toProfile" class="likeBtn"><i class="material-icons" >thumb_up_alt</i>Like</button>
 
                                    </form>
                                  </td>
@@ -170,7 +170,7 @@
                            <input type="text" name="userID" style="display:none" value = "<%= userID%>">
                            <input type="text" name="WallID" style="display:none" value = "<%= WallID%>">
                            <input type="text" name="name" style="display:none" value = "<%= name%>">
-                           <button name="toProfile" class="toProfile"><i class="material-icons" style="float: left;padding-right:10px;">account_circle</i> dislike</button>
+                           <button name="toProfile" class="dislikeBtn"><i class="material-icons">thumb_down_alt</i>Dislike</button>
                        </form> </td>
                             <span class="postText">
 
@@ -193,7 +193,7 @@
 
 
 
-                            <td> <button name="toCommentPage" id="toCommentPage" >View Comments for this Post</button> </td>
+                            <td> <button name="toCommentPage" class="toCommentPageBtn" >Comments </button> </td>
                                 </form>
 
                         </tr>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -114,21 +114,20 @@
                 <table class="profileInfoTable">
 
 
-                        <tr>
+                        <tr class="tableInfoRow">
                                 <td><span class="info">Account Type: </span></td>
                                 <td> <span name="accountTp" class="userInfo"><%= userType%></span></td>
 
 
                         </tr>
 
-                    <tr>
+                        <tr class="tableInfoRow">
                             <td><span class="info">Email :</span></td>
                             <td><span name="userEmail" class="userInfo"> <%= userEmail%> </span></td>
                     </tr>
 
 
-                    <tr>
-
+                    <tr class="tableInfoRow">
                             <td><span class="info">User ID :</span></td>
                             <td><span name="childID" class="userInfo"><%= userID%> </span></td>
 
@@ -136,7 +135,7 @@
 
 
 
-                    <tr>
+                        <tr class="tableInfoRow">
                             <td><span class="info">Password :</span></td>
                             <td><span name="userPass" class="userInfo"> <%= userPass%>   </span></td>
 
@@ -154,14 +153,14 @@
 
                     <table class="editProfileInfoTable">
 
-                      <tr>
+                            <tr class="tableInfoRow">
                             <td><span class="editInfoTxt">First Name:  </span></td>
                             <td> <input type="text" id = "userFNameEdit" name="userFNameEdit" class="editUserInfo" value="<%= name%>"></td>
 
 
                     </tr>
 
-                    <tr>
+                    <tr class="tableInfoRow">
 
                             <td><span class="editInfoTxt">Family Name: </span></td>
                             <td> <input type="text" name="userLNameEdit" class="editUserInfo"  value="<%= userLname%>"></td>
@@ -169,15 +168,14 @@
 
                      </tr>
 
-
-                     <tr>
+                     <tr class="tableInfoRow">
                             <td><span class="editInfoTxt">Account Type: </span></td>
                             <td> <input type="text" name="accountTpEdit" class="editUserInfo" id="accountType" disabled value="<%= userType%>" ></td>
 
 
                     </tr>
 
-                    <tr>
+                    <tr class="tableInfoRow">
 
                             <td><span class="editInfoTxt">Change Email :</span></td>
                             <td><input type="email" name="userEmailEdit" class="editUserInfo" disabled value=" <%= userEmail%>"></td>
@@ -185,14 +183,14 @@
                     </tr>
 
 
-                    <tr>
+                    <tr class="tableInfoRow">
 
                             <td><span class="editInfoTxt">Change User ID :</span></td>
                             <td><input type="text" name="userIDEdit" class="editUserInfo" disabled value="<%= userID%>"></td>
 
                     </tr>
 
-                    <tr>
+                    <tr class="tableInfoRow">
                             <td><span class="editInfoTxt">Change Password :</span></td>
                             <td><input type="password" name="userPassEdit" class="editUserInfo"  value="<%= userPass%>"></td>
 


### PR DESCRIPTION
This pull request handles Issue #117 along with all it's sub tasks (Issue #128 and #134).

**Summary of changes :** 

- Users can now go their friends' profile and view which groups their friends are part of.
- A User can go to a particular group page from their friends profile.
- A message appears at the top of the group page indicating to the user their status within the group.
- A user can either be a **regular member**, **not a member** or a **leader/admin**. 

1.  A group **leader/admin** can add new users to the group by using the search feature.
A group leader can view pending requests from other users who wish to join the group.
A group leader can either accept or decline the requests.
(Not yet implemented) A group leader can kick users from the group. 

2. A **regular member** can add new users to the group but cannot kick users.
A regular member can use the search feature to find and add new members.
A regular member cannot view pending requests from other users wishing to join the group. 

3. A **non-member**  who wishes to join the group can send a request to the group leader using a button next to their status message at the top of the page. 
A non member can search for users but cannot add them to the group.
A non member can view the current members of the group but cannot view pending requests.